### PR TITLE
Patch RMT to consider Redis password query

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,11 @@
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.3.6</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
# Consider Redis Password in RMT

The documentation states that you can pass in `authPassword` as a query option into the `rmt` tool's `-m,--migrate <uri>` option. There was an issue where passing the parameter wasn't being considered. This fixes the issue by explicitly searching for the query parameter and adding it to the configuration if it exists.

---

**This contribution is a courtesy of [Kater Technologies](https://kater.com)**

---