### PR TITLE
Update image to enable support for Apple silicon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY . /app
 RUN mvn clean install -Dmaven.test.skip=true
 
-FROM adoptopenjdk/openjdk11:alpine
+FROM bellsoft/liberica-openjdk-alpine-musl:11
 COPY --from=builder /app/target/redis-rdb-cli-release.zip /tmp/redis-rdb-cli-release.zip
 WORKDIR /app
 # because of the cli has set shebang


### PR DESCRIPTION
Currently, the Docker image doesn't build or run on Apple silicon computers (M1/M2).
This PR changes the base OpenJDK image to one that supports Apple silicon.
The new image was selected based on [this](https://stackoverflow.com/a/70560947/1403643) Stackoverflow answer.